### PR TITLE
Add multi-report support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ report/
 dist/
 inputs/
 outputs/
+*.vsix

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
   "name": "azure-pipelines-cucumber",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Embed Protractor HTML result into release and build tabs",
   "main": "index.js",
   "scripts": {
-    "build": "tsc -p ."
+    "build": "tsc -p .",
+    "package": "tfx extension create --root . --env dev --manifest-globs vss-extension.json",
+    "gallery-publish": "tfx extension publish --token $PAT",
+    "clean": "rimraf ./dist && rimraf ./*.vsix",
+    "bump-version": "node utils/bump-version.js",
+    "build-publish": "npm run clean && npm run bump-version && npm run build && npm run package && npm run gallery-publish"
   },
   "repository": {
     "type": "git",
@@ -16,6 +21,9 @@
     "Cucumber"
   ],
   "author": "Maciej Maciejewski <maciej.maciejewski@finastra.com>",
+  "contributors": [
+    "selamanse <selamanse@scheinfrei.info>"
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/maciejmaciejewski/azure-pipelines-cucumber/issues"
@@ -26,6 +34,8 @@
   },
   "devDependencies": {
     "@types/node": "^13.7.4",
+    "semver": "^7.3.5",
+    "tfx-cli": "^0.9.3",
     "typescript": "^3.9.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-cucumber",
-  "version": "1.0.8",
+  "version": "1.0.7",
   "description": "Embed Protractor HTML result into release and build tabs",
   "main": "index.js",
   "scripts": {

--- a/tab.html
+++ b/tab.html
@@ -11,7 +11,16 @@
         paths: {"enhancer": "scripts"}
       }
     });
-    let noop = function () {
+
+    let noop = function () {};
+
+    let displayReportFrame = function (reportFrame) {
+      $(".cucumber-result").css("display", "none")
+      $(".cucumber-result").contents().find('html').html("about:none")
+
+      $(`#${reportFrame}`)
+        .attr("srcdoc", $(`#${reportFrame}`).attr('temp_src'))
+        .show()
     };
 
     VSS.ready(function () {
@@ -50,7 +59,7 @@
     }
     .wide {
       position: absolute;
-      top: 20px;
+      top: 45px;
       left: 0;
       width: 100%;
       height: 96%;
@@ -59,8 +68,16 @@
       box-shadow: 0 2px 6px 2px rgba(0, 0, 0, .05);
     }
 
-    #cucumber-result {
+    .cucumber-result {
       display: none
+    }
+
+    #cucumber-report-frame-menu{
+      position: absolute;
+      top: 5px;
+      display: none;
+      padding-bottom: 10px;
+      padding-left: 10px;
     }
 
     #waiting p {
@@ -108,12 +125,13 @@
 
 <body>
 <div id="container">
+  <div id="cucumber-report-frame-menu"><span>available reports: </span></div>
   <div id="waiting" class="wide">
     <div class="spinner"></div>
     <div class="error-badge"></div>
     <p>Waiting for task results...</p>
   </div>
-  <iframe id="cucumber-result" class="wide" src="about:blank"></iframe>
+  <iframe id="cucumber-result" class="cucumber-result wide" src="about:blank"></iframe>
 </div>
 </body>
 </html>

--- a/tasks/PublishCucumberReport/index.js
+++ b/tasks/PublishCucumberReport/index.js
@@ -96,8 +96,8 @@ try {
     throw new Error('Failed to run script')
   }
 
-  console.log(`Uploading HTML report ${outputReportFile}`)
-  tl.addAttachment('cucumber.report', 'cucumber_report.html', outputReportFile)
+  console.log(`Uploading attachment file: ${outputReportFile} as type cucumber.report with name ${REPORT_NAME}.html`)
+  tl.addAttachment('cucumber.report', `${REPORT_NAME}.html`, outputReportFile)
 
   const screenshots = globby.sync(`${outputPath.replace(/\\/g, '/')}/screenshots/**.png`)
   screenshots.forEach(screenshotPath => {

--- a/utils/bump-version.js
+++ b/utils/bump-version.js
@@ -1,0 +1,19 @@
+const fs = require('fs')
+const path = require('path')
+const semver = require('semver')
+
+const packageFile = path.resolve(__dirname, '../package.json')
+const vssExtensionFile = path.resolve(__dirname, '../vss-extension.json')
+
+const package = require(packageFile)
+const vssExtension = require(vssExtensionFile)
+
+const currentVersion = package.version
+console.log(`current version ${package.version}`)
+package.version = semver.inc(currentVersion, 'patch', {}, null)
+console.log(`next version ${package.version}`)
+vssExtension.version = package.version
+
+fs.writeFileSync(packageFile, JSON.stringify(package, null, 2))
+fs.writeFileSync(vssExtensionFile, JSON.stringify(vssExtension, null, 2))
+console.log('done.')

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -5,7 +5,7 @@
     "publisher": "MaciejMaciejewski",
     "public": false,
     "author": "Maciej Maciejewski",
-    "version": "1.0.8",
+    "version": "1.0.7",
     "description": "Embed Cucumber HTML report in Azure Pipelines",
     "galleryFlags": [],
     "repository": {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -5,7 +5,7 @@
     "publisher": "MaciejMaciejewski",
     "public": false,
     "author": "Maciej Maciejewski",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "description": "Embed Cucumber HTML report in Azure Pipelines",
     "galleryFlags": [],
     "repository": {


### PR DESCRIPTION
this change allows to open all cucumber.report attachments by providing a tab system inside the container.
it's been functionally tested on azure devops with chrome 96

![Screenshot 2021-12-18 at 01 02 31](https://user-images.githubusercontent.com/3129224/146621071-e6842e62-44f9-4804-a0f8-0badf26fc0ef.png)

hopefully
fixes #30
fixes #19