### PR TITLE
update from node10 to node16

### DIFF
--- a/tasks/PublishCucumberReport/task.json
+++ b/tasks/PublishCucumberReport/task.json
@@ -87,7 +87,7 @@
     }
   ],
   "execution": {
-    "Node10": {
+    "Node16": {
       "target": "index.js",
       "argumentFormat": ""
     }


### PR DESCRIPTION
There is a warning thrown by ADO about end of life cycle for node10. This fix should remove the warning on ADO and bump version to 16