### PR TITLE
#52 bump up cucumber reporter version for large json files

### DIFF
--- a/tasks/PublishCucumberReport/reporter/package.json
+++ b/tasks/PublishCucumberReport/reporter/package.json
@@ -3,6 +3,6 @@
     "start": "node script.js"
   },
   "dependencies": {
-    "cucumber-html-reporter": "5.5.1"
+    "cucumber-html-reporter": "7.2.0"
   }
 }


### PR DESCRIPTION
should contain a fix for RangeError: Maximum call stack size exceeded mentioned in #52.
fix provided in the parent library through https://github.com/gkushang/cucumber-html-reporter/commit/de4d274a47d54c9cf39c039ff6e5557b9599f58c