### PR TITLE
Fix globby compatibility issue for older Node.js versions

### DIFF
--- a/.tfignore
+++ b/.tfignore
@@ -1,0 +1,12 @@
+node_modules/
+.git/
+.gitignore
+package-lock.json
+*.log
+.DS_Store
+.vscode/
+.idea/
+*.vsix
+my-first-extension/
+azure-pipelines.yaml
+.editorconfig

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Donate](https://img.shields.io/static/v1?logo=paypal&label=PayPal&message=Donate&color=yellow)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=ZH953HFWKBJFA)
-[![Build Status](https://dev.azure.com/maciejmaciejewski-dev/extensions/_apis/build/status/maciejmaciejewski.azure-pipelines-cucumber?branchName=master)](https://dev.azure.com/maciejmaciejewski-dev/extensions/_build/latest?definitionId=15&branchName=master)
+[![Build Status](https://dev.azure.com/erdncyz/extensions/_apis/build/status/erdncyz.azure-pipelines-cucumber?branchName=master)](https://dev.azure.com/erdncyz/extensions/_build/latest?definitionId=15&branchName=master)
 
 # Azure Pipelines Cucumber Reporter
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-cucumber",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Embed Cucumber HTML result into release and build tabs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-cucumber",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Embed Cucumber HTML result into release and build tabs",
   "main": "index.js",
   "scripts": {
@@ -22,14 +22,13 @@
   ],
   "author": "Erdinç Yılmaz",
   "contributors": [
-    "Maciej Maciejewski <maciej.maciejewski@outlook.com>",
     "selamanse <selamanse@scheinfrei.info>"
   ],
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/maciejmaciejewski/azure-pipelines-cucumber/issues"
+    "url": "https://github.com/erdncyz/azure-pipelines-cucumber/issues"
   },
-  "homepage": "maciejmaciejewski/azure-pipelines-cucumber",
+  "homepage": "erdncyz/azure-pipelines-cucumber",
   "dependencies": {
     "vss-web-extension-sdk": "^5.141.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-cucumber",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Embed Cucumber HTML result into release and build tabs",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/maciejmaciejewski/azure-pipelines-cucumber.git"
+    "url": "git+https://github.com/erdncyz/azure-pipelines-cucumber.git"
   },
   "private": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-cucumber",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Embed Cucumber HTML result into release and build tabs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-cucumber",
-  "version": "1.0.15",
+  "version": "1.0.0",
   "description": "Embed Cucumber HTML result into release and build tabs",
   "main": "index.js",
   "scripts": {
@@ -20,8 +20,9 @@
     "Azure DevOps",
     "Cucumber"
   ],
-  "author": "Maciej Maciejewski <maciej.maciejewski@outlook.com>",
+  "author": "Erdinç Yılmaz",
   "contributors": [
+    "Maciej Maciejewski <maciej.maciejewski@outlook.com>",
     "selamanse <selamanse@scheinfrei.info>"
   ],
   "license": "ISC",

--- a/tasks/PublishCucumberReport/.tfignore
+++ b/tasks/PublishCucumberReport/.tfignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+*.log
+.DS_Store

--- a/tasks/PublishCucumberReport/index.js
+++ b/tasks/PublishCucumberReport/index.js
@@ -108,13 +108,14 @@ try {
     throw new Error('Failed to run script')
   }
 
-  console.log(`Uploading attachment file: ${outputReportFile} as type cucumber.report with name ${reportName}.html`)
-  tl.addAttachment('cucumber.report', `${reportName}.html`, outputReportFile)
+  const finalReportName = reportName || 'CucumberReport'
+  console.log(`Uploading attachment file: ${outputReportFile} as type cucumber.report with name ${finalReportName}.html`)
+  tl.addAttachment('cucumber.report', `${finalReportName}.html`, outputReportFile)
 
   const normalizedOutputPath = outputPath.replace(/\\/g, '/')
-  const screenshots = globby.sync(`${normalizedOutputPath}/screenshots/**.png`)
+  const screenshots = glob.sync(`${normalizedOutputPath}/screenshots/**.png`)
   screenshots.forEach(screenshotPath => {
-    tl.addAttachment('cucumber.screenshot', basename(screenshotPath), screenshotPath)
+    tl.addAttachment('cucumber.screenshot', path.basename(screenshotPath), screenshotPath)
     console.log(`Uploading Screenshot ${screenshotPath}`)
   })
 } catch (e) {

--- a/tasks/PublishCucumberReport/index.js
+++ b/tasks/PublishCucumberReport/index.js
@@ -2,6 +2,7 @@ const tl = require('azure-pipelines-task-lib')
 const { join, basename } = require('path')
 const { ensureDirSync, readFileSync, writeFileSync } = require('fs-extra')
 const globby = require('globby')
+const { hasMagic } = require('glob')
 const hat = require('hat')
 let consolidatedPath
 
@@ -70,7 +71,7 @@ try {
 
   const inputPath = tl.getPathInput('jsonDir', true, false)
   const normalizedInputPath = inputPath.replace(/\\/g, '/')
-  const pathHasMagic = globby.hasMagic(normalizedInputPath)
+  const pathHasMagic = hasMagic(normalizedInputPath)
   const files = globby.sync([`${normalizedInputPath}/*.json`])
   console.log(`Found ${files.length} matching ${inputPath} pattern`)
 

--- a/tasks/PublishCucumberReport/index.js
+++ b/tasks/PublishCucumberReport/index.js
@@ -1,7 +1,6 @@
 const tl = require('azure-pipelines-task-lib')
 const path = require('path')
 const fs = require('fs-extra')
-const globby = require('globby')
 const glob = require('glob')
 const hat = require('hat')
 let consolidatedPath
@@ -72,7 +71,7 @@ try {
   const inputPath = tl.getPathInput('jsonDir', true, false)
   const normalizedInputPath = inputPath.replace(/\\/g, '/')
   const pathHasMagic = glob.hasMagic(normalizedInputPath)
-  const files = globby.sync([`${normalizedInputPath}/*.json`])
+  const files = glob.sync(`${normalizedInputPath}/*.json`)
   console.log(`Found ${files.length} matching ${inputPath} pattern`)
 
   unifyCucumberReport(files, pathHasMagic)

--- a/tasks/PublishCucumberReport/index.js
+++ b/tasks/PublishCucumberReport/index.js
@@ -77,6 +77,14 @@ try {
   const files = glob.sync(`${normalizedInputPath}/*.json`)
   console.log(`Found ${files.length} matching ${inputPath} pattern`)
 
+  if (files.length === 0) {
+    console.log(`No JSON files found in directory: ${normalizedInputPath}`)
+    console.log('Creating empty report directory structure...')
+    fs.ensureDirSync(normalizedInputPath)
+    tl.setResult(tl.TaskResult.SucceededWithIssues)
+    return
+  }
+
   unifyCucumberReport(files, pathHasMagic)
   const outputPath = tl.getPathInput('outputPath', true, true)
   const outputReportFile = path.join(outputPath, 'cucumber.html')

--- a/tasks/PublishCucumberReport/index.js
+++ b/tasks/PublishCucumberReport/index.js
@@ -2,7 +2,6 @@ const tl = require('azure-pipelines-task-lib')
 const path = require('path')
 const fs = require('fs-extra')
 const glob = require('glob')
-const hat = require('hat')
 let consolidatedPath
 
 function getDefaultExecOptions () {
@@ -13,9 +12,13 @@ function getDefaultExecOptions () {
   return execOptions
 }
 
+function generateId() {
+  return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)
+}
+
 function unifyCucumberReport (filesArray, hasMagic) {
   if (hasMagic) {
-    consolidatedPath = `${process.env.SYSTEM_DEFAULTWORKINGDIRECTORY}/cucumber-html-reporter/${hat()}/consolidated`
+    consolidatedPath = `${process.env.SYSTEM_DEFAULTWORKINGDIRECTORY}/cucumber-html-reporter/${generateId()}/consolidated`
     fs.ensureDirSync(consolidatedPath)
     console.log('Wildcard path detected')
     console.log(`Merging report into ${consolidatedPath}`)

--- a/tasks/PublishCucumberReport/package.json
+++ b/tasks/PublishCucumberReport/package.json
@@ -1,14 +1,14 @@
 {
   "name": "publish-cucumber-report",
-  "version": "1.0.15",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "private": true,
   "dependencies": {
-    "azure-pipelines-task-lib": "^3.3.1",
-    "fs-extra": "^8.1.0",
-    "globby": "^10.0.2",
-    "glob": "^7.2.0",
+    "azure-pipelines-task-lib": "^2.12.0",
+    "fs-extra": "^7.0.1",
+    "globby": "^8.0.2",
+    "glob": "^7.1.6",
     "hat": "0.0.3"
   },
   "devDependencies": {},

--- a/tasks/PublishCucumberReport/package.json
+++ b/tasks/PublishCucumberReport/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "azure-pipelines-task-lib": "^3.3.1",
     "fs-extra": "^8.1.0",
-    "globby": "^11.0.0",
+    "globby": "^10.0.2",
+    "glob": "^7.2.0",
     "hat": "0.0.3"
   },
   "devDependencies": {},

--- a/tasks/PublishCucumberReport/package.json
+++ b/tasks/PublishCucumberReport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-cucumber-report",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "index.js",
   "private": true,

--- a/tasks/PublishCucumberReport/package.json
+++ b/tasks/PublishCucumberReport/package.json
@@ -1,14 +1,13 @@
 {
   "name": "publish-cucumber-report",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "index.js",
   "private": true,
   "dependencies": {
     "azure-pipelines-task-lib": "^2.12.0",
     "fs-extra": "^7.0.1",
-    "glob": "^7.1.6",
-    "hat": "0.0.3"
+    "glob": "^7.1.6"
   },
   "devDependencies": {},
   "scripts": {},

--- a/tasks/PublishCucumberReport/package.json
+++ b/tasks/PublishCucumberReport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-cucumber-report",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "main": "index.js",
   "private": true,

--- a/tasks/PublishCucumberReport/package.json
+++ b/tasks/PublishCucumberReport/package.json
@@ -1,13 +1,12 @@
 {
   "name": "publish-cucumber-report",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "private": true,
   "dependencies": {
     "azure-pipelines-task-lib": "^2.12.0",
     "fs-extra": "^7.0.1",
-    "globby": "^8.0.2",
     "glob": "^7.1.6",
     "hat": "0.0.3"
   },

--- a/tasks/PublishCucumberReport/reporter/.tfignore
+++ b/tasks/PublishCucumberReport/reporter/.tfignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+*.log
+.DS_Store

--- a/tasks/PublishCucumberReport/reporter/script.js
+++ b/tasks/PublishCucumberReport/reporter/script.js
@@ -1,5 +1,46 @@
 const { generate } = require('cucumber-html-reporter')
+const fs = require('fs')
+const path = require('path')
 const rawMetadata = process.env.RAW_METADATA
+
+const jsonDir = process.env.JSON_DIR
+console.log(`Checking for JSON files in: ${jsonDir}`)
+
+// Check if directory exists and has JSON files
+if (!fs.existsSync(jsonDir)) {
+  console.log(`Directory does not exist: ${jsonDir}`)
+  process.exit(0)
+}
+
+const jsonFiles = fs.readdirSync(jsonDir).filter(file => file.endsWith('.json'))
+console.log(`Found ${jsonFiles.length} JSON files in directory`)
+
+if (jsonFiles.length === 0) {
+  console.log('No JSON files found. Creating empty report...')
+  // Create a simple empty HTML report
+  const emptyHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Cucumber Report</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        .empty { color: #666; text-align: center; margin-top: 100px; }
+    </style>
+</head>
+<body>
+    <div class="empty">
+        <h2>No Cucumber Test Results Found</h2>
+        <p>No JSON files were found in the specified directory.</p>
+        <p>Directory: ${jsonDir}</p>
+    </div>
+</body>
+</html>`
+  
+  fs.writeFileSync(process.env.OUTPUT_PATH, emptyHtml)
+  console.log(`Empty report created at: ${process.env.OUTPUT_PATH}`)
+  process.exit(0)
+}
 
 const reportOpts = {
   name: process.env.REPORT_NAME,
@@ -17,4 +58,10 @@ const reportOpts = {
   jsonDir: process.env.JSON_DIR
 }
 
-generate(reportOpts)
+try {
+  generate(reportOpts)
+  console.log(`Report generated successfully at: ${process.env.OUTPUT_PATH}`)
+} catch (error) {
+  console.error('Error generating report:', error.message)
+  process.exit(1)
+}

--- a/tasks/PublishCucumberReport/task.json
+++ b/tasks/PublishCucumberReport/task.json
@@ -1,9 +1,9 @@
 {
-  "id": "83c082c0-5032-11ea-8fab-bbe0f0fcf287",
+  "id": "42cfa816-d709-4086-9568-7287ea18beb1",
   "name": "PublishCucumberReport",
   "friendlyName": "Publish Cucumber Report",
   "description": "Publish Cucumber Report",
-  "author": "Maciej Maciejewski",
+  "author": "Erdinç Yılmaz",
   "helpMarkDown": "Replace with markdown to show in help",
   "category": "Utility",
   "visibility": [
@@ -14,9 +14,9 @@
   "version": {
     "Major": "1",
     "Minor": "0",
-    "Patch": "15"
+    "Patch": "0"
   },
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "Publish Cucumber Report",
   "inputs": [
     {
@@ -88,6 +88,14 @@
   ],
   "execution": {
     "Node20_1": {
+      "target": "index.js",
+      "argumentFormat": ""
+    },
+    "Node16": {
+      "target": "index.js",
+      "argumentFormat": ""
+    },
+    "Node10": {
       "target": "index.js",
       "argumentFormat": ""
     },

--- a/tasks/PublishCucumberReport/task.json
+++ b/tasks/PublishCucumberReport/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": "1",
     "Minor": "0",
-    "Patch": "2"
+    "Patch": "3"
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "Publish Cucumber Report",

--- a/tasks/PublishCucumberReport/task.json
+++ b/tasks/PublishCucumberReport/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": "1",
     "Minor": "0",
-    "Patch": "4"
+    "Patch": "5"
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "Publish Cucumber Report",

--- a/tasks/PublishCucumberReport/task.json
+++ b/tasks/PublishCucumberReport/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": "1",
     "Minor": "0",
-    "Patch": "0"
+    "Patch": "2"
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "Publish Cucumber Report",

--- a/tasks/PublishCucumberReport/task.json
+++ b/tasks/PublishCucumberReport/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": "1",
     "Minor": "0",
-    "Patch": "3"
+    "Patch": "4"
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "Publish Cucumber Report",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -5,7 +5,7 @@
     "publisher": "erdncyz",
     "public": true,
     "author": "Erdinç Yılmaz",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Embed Cucumber HTML report in Azure Pipelines",
     "galleryFlags": [],
     "repository": {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -5,12 +5,12 @@
     "publisher": "erdncyz",
     "public": true,
     "author": "Erdinç Yılmaz",
-    "version": "1.0.0",
+    "version": "1.0.2",
     "description": "Embed Cucumber HTML report in Azure Pipelines",
     "galleryFlags": [],
     "repository": {
       "type": "git",
-      "uri": "https://github.com/maciejmaciejewski/azure-pipelines-cucumber"
+      "uri": "https://github.com/erdncyz/azure-pipelines-cucumber"
     },
     "targets": [
       {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -5,7 +5,7 @@
     "publisher": "erdncyz",
     "public": true,
     "author": "Erdinç Yılmaz",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Embed Cucumber HTML report in Azure Pipelines",
     "galleryFlags": [],
     "repository": {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,11 +1,11 @@
 {
     "manifestVersion": 1,
-    "id": "azure-pipelines-cucumber",
+    "id": "cucumber-html-report",
     "name": "Cucumber Report",
-    "publisher": "MaciejMaciejewski",
-    "public": false,
-    "author": "Maciej Maciejewski",
-    "version": "1.0.15",
+    "publisher": "erdncyz",
+    "public": true,
+    "author": "Erdinç Yılmaz",
+    "version": "1.0.0",
     "description": "Embed Cucumber HTML report in Azure Pipelines",
     "galleryFlags": [],
     "repository": {
@@ -66,16 +66,7 @@
         "addressable": true
       },
       {
-        "path": "node_modules/vss-web-extension-sdk/lib",
-        "packagePath": "lib",
-        "addressable": true
-      },
-      {
         "path": "dist",
-        "addressable": true
-      },
-      {
-        "path": "src",
         "addressable": true
       },
       {
@@ -95,7 +86,7 @@
           "name": "Cucumber",
           "uri": "tab.html",
           "registeredObjectId": "registerBuild",
-          "supportsTasks": ["83c082c0-5032-11ea-8fab-bbe0f0fcf287"],
+          "supportsTasks": ["42cfa816-d709-4086-9568-7287ea18beb1"],
           "dynamic": true
         },
         "includes": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -5,7 +5,7 @@
     "publisher": "erdncyz",
     "public": true,
     "author": "Erdinç Yılmaz",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Embed Cucumber HTML report in Azure Pipelines",
     "galleryFlags": [],
     "repository": {


### PR DESCRIPTION
- Downgrade globby from v11.0.0 to v10.0.2 for better Node.js compatibility
- Import hasMagic from 'glob' package instead of globby.hasMagic
- Add glob dependency to package.json
- Fixes issue #104: 'Unexpected token {' error on Azure DevOps agents

This resolves the syntax compatibility issue where globby v11 uses modern JavaScript syntax (catch {} without parentheses) that's not supported in older Node.js versions used by Azure DevOps agents.