### PR TITLE
Update package.json

### DIFF
--- a/tasks/PublishCucumberReport/reporter/package.json
+++ b/tasks/PublishCucumberReport/reporter/package.json
@@ -3,6 +3,6 @@
     "start": "node script.js"
   },
   "dependencies": {
-    "cucumber-html-reporter": "7.2.0"
+    "cucumber-html-reporter": "7.1.0"
   }
 }


### PR DESCRIPTION
Since cucumber-html-reporter version 7.2.0 has vulnarability issues and is being blocked by npm, reverting to version 7.1.0 which passes the vulnarability scanner from NPM
https://secure.software/npm/packages/cucumber-html-reporter/vulnerabilities