### PR TITLE
reverted back to cucumber-html-reporter 7.1.0 because of being blocked by npm

### DIFF
--- a/tasks/PublishCucumberReport/reporter/package.json
+++ b/tasks/PublishCucumberReport/reporter/package.json
@@ -3,6 +3,6 @@
     "start": "node script.js"
   },
   "dependencies": {
-    "cucumber-html-reporter": "7.2.0"
+    "cucumber-html-reporter": "7.1.0"
   }
 }


### PR DESCRIPTION
cucumber-html-reporter version 7.2.0 has vulnarability issues and is being blocked by npm, so reverting back to 7.1.0 which doesn't have these
https://secure.software/npm/packages/cucumber-html-reporter/vulnerabilities