### PR TITLE
Remove NodeJS version '6' task runner support

### DIFF
--- a/tasks/PublishCucumberReport/task.json
+++ b/tasks/PublishCucumberReport/task.json
@@ -87,6 +87,10 @@
     }
   ],
   "execution": {
+    "Node24": {
+      "target": "index.js",
+      "argumentFormat": ""
+    },
     "Node20_1": {
       "target": "index.js",
       "argumentFormat": ""
@@ -95,19 +99,7 @@
       "target": "index.js",
       "argumentFormat": ""
     },
-    "Node14": {
-      "target": "index.js",
-      "argumentFormat": ""
-    },
-    "Node12": {
-      "target": "index.js",
-      "argumentFormat": ""
-    },
     "Node10": {
-      "target": "index.js",
-      "argumentFormat": ""
-    },
-    "Node": {
       "target": "index.js",
       "argumentFormat": ""
     }


### PR DESCRIPTION
Remove Node 6 task runner support and add latest Node 24 support instead.
With this change, Azure DevOps can be configured to disable Node 6 tasks.